### PR TITLE
Add register page and update auth buttons

### DIFF
--- a/components/auth/AuthButton.tsx
+++ b/components/auth/AuthButton.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useSession } from 'next-auth/react'
+import Link from 'next/link'
 import { useAuthSync } from '../../hooks/useFirebaseNextAuth'
 
 interface AuthButtonProps {
@@ -22,11 +23,19 @@ export default function AuthButton({ onLoginClick }: AuthButtonProps) {
 
   /* ------------- Logged-out ➜ show Sign-in / Sign-up -------------- */
   return (
-    <button
-      onClick={onLoginClick}
-      className="px-4 py-1 bg-main text-background rounded"
-    >
-      Log in / Sign up
-    </button>
+    <div className="flex space-x-2">
+      <button
+        onClick={onLoginClick}
+        className="px-4 py-1 bg-main text-background rounded"
+      >
+        Log in
+      </button>
+      <Link
+        href="/register"
+        className="px-4 py-1 bg-main text-background rounded"
+      >
+        Sign up
+      </Link>
+    </div>
   )
 }

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -1,0 +1,11 @@
+import { useEffect } from 'react'
+import { useAuthModalManager } from '../contexts/AuthModalManagerContext'
+
+export default function RegisterPage() {
+  const { setMode } = useAuthModalManager()
+  useEffect(() => {
+    setMode('register')
+  }, [setMode])
+
+  return null
+}


### PR DESCRIPTION
## Summary
- create a `/register` page that opens the registration modal
- split the `AuthButton` into separate **Log in** and **Sign up** actions

## Testing
- `npm run lint` *(fails: parsing/TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_684029cff9b88322bb0560c2be82e236